### PR TITLE
Add .editorconfig for uniform IDE codestyle

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+# https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+# end_of_line = crlf
+indent_style = tab
+indent_size = 4
+tab_width = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+# spaces_around_operators = true
+# spaces_around_brackets = both
+
+[*.txt]
+trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ root = true
 
 [*]
 charset = utf-8
-# end_of_line = crlf
+end_of_line = lf
 indent_style = tab
 indent_size = 4
 tab_width = 4


### PR DESCRIPTION
This PR will add the .editorconfig will prefilled for WordPress coding standards regarding to indentation.
Whenever you or contributors will use this repo for contributing their IDE will automatically set the correct settings for indentation etc.

It's a minor enhancement for ensuring proper codestyle :)